### PR TITLE
ci: publish to npmjs on release

### DIFF
--- a/.github/workflows/publish-to-npmjs.yml
+++ b/.github/workflows/publish-to-npmjs.yml
@@ -1,0 +1,18 @@
+name: Publish package to npmjs
+on:
+ release:
+  types: [created]
+jobs:
+ build:
+  runs-on: ubuntu-latest
+  steps:
+   - uses: actions/checkout@v3
+   # Setup .npmrc file to publish to npm
+   - uses: actions/setup-node@v3
+     with:
+      node-version: 'lts/*'
+      registry-url: 'https://registry.npmjs.org'
+   - run: npm ci
+   - run: npm publish
+     env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Upon creating a GitHub release, the package will be automatically published to the npmjs registry.